### PR TITLE
chore: add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "repository": "git@github.com:spadgett/console-plugin-template.git",
+  "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf dist",
     "build": "yarn clean && NODE_ENV=production yarn ts-node node_modules/.bin/webpack",


### PR DESCRIPTION
Without the license field you will get warnings of the type "warning ../package.json: No license field"

Attached license in this project is Apache v2: [https://github.com/spadgett/console-plugin-template/blob/main/LICENSE](https://github.com/spadgett/console-plugin-template/blob/aeb42d4cbbd1203538b753ff949b2f365c15ec6c/LICENSE).